### PR TITLE
Modify typescript rules for development

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,10 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": false
   },
   "exclude": [
     "node_modules",

--- a/tslint.json
+++ b/tslint.json
@@ -33,7 +33,7 @@
         "no-arg": true,
         "no-bitwise": true,
         "no-console": [
-            true,
+            false,
             "log",
             "error",
             "debug",
@@ -75,7 +75,7 @@
             "property-declaration"
         ],
         "typedef-whitespace": [
-            true,
+            false,
             {
                 "call-signature": "nospace",
                 "index-signature": "nospace",
@@ -86,7 +86,7 @@
         ],
         "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore", "allow-pascal-case"],
         "whitespace": [
-            true,
+            false,
             "check-branch",
             "check-decl",
             "check-module",

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": ["tslint-react"],
     "rules": {
+        "no-unsafe-any": false,
         "align": [
             true,
             "parameters",
@@ -29,8 +30,8 @@
             "static-before-instance",
             "variables-before-functions"
         ],
-        "no-any": true,
-        "no-arg": true,
+        "no-any": false,
+        "no-arg": false,
         "no-bitwise": true,
         "no-console": [
             false,
@@ -55,7 +56,7 @@
         "no-unused-expression": true,
         "no-use-before-declare": true,
         "one-line": [
-            true,
+            false,
             "check-catch",
             "check-else",
             "check-open-brace",
@@ -70,7 +71,7 @@
 
         "triple-equals": [ true, "allow-null-check" ],
         "typedef": [
-            true,
+            false,
             "parameter",
             "property-declaration"
         ],


### PR DESCRIPTION
Just try to do development without disabling some of these rules. I wasted hours. It is especially bad with the auto-compile of webpack.

I agree these aren't what we want for production builds but like @jotak suggested yesterday, it looks like we need a dev and prod separation. Someone can create a task for that.

[Create UI Scaffolding](https://issues.jboss.org/browse/SWS-56)