### PR TITLE
WIP: Add High Order Component for wrapping components without a div

### DIFF
--- a/src/hoc/DivlessWrapper.tsx
+++ b/src/hoc/DivlessWrapper.tsx
@@ -1,0 +1,6 @@
+// Allows us to not use a traditional <div> tag to return results (which can cause rendering issues)
+// this gives us a div less wrapper around child components
+
+const divlessWrapper = (props) => props.children;
+
+export default divlessWrapper;


### PR DESCRIPTION
A handy HoC for wrapping components without a div. Because sometimes the wrapping div actually visually effects the page.

[Create UI Scaffolding](https://issues.jboss.org/browse/SWS-56)