### PR TITLE
Set noImplicitAny flag in tsconfig.json to false 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true


### PR DESCRIPTION
Set noImplicitAny flag in tsconfig.json to false so we can use 3rd pa…rty libaries without @type libs.

I could not use the cytoscape.js library without this because it has no type libraries (*.d.ts)