### PR TITLE
Add editorconfig, the universal editor config settings

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false


### PR DESCRIPTION
So folks can just get the right settings for the editor and have the IDE 'know' the right settings for indent spacing etc...

Most IDEs and editors support this.

http://editorconfig.org/