### PR TITLE
Adds information on how to configure proxy to swscore server

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,41 @@ But, if it doesn't then use:
 This launches a development environment that instantly
 reloads any changes to the browser for rapid development.
 
+== Developing
+
+When developing, is usual to run this application outside of https://github.com/swift-sunshine/swscore[swscore].
+
+Is possible to proxy the API requests without having to push the changes to swscore.
+Add the https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#proxying-api-requests-in-development[proxy]
+property to `package.json` with the url of the swscore.
+[source, json]
+----
+{
+  "name": "swsui",
+  "version": "0.2.1",
+  "proxy": "http://sws-istio-system.127.0.0.1.nip.io",
+  "bugs": {
+...
+----
+
+Run `npm start` and try it!
+[source, bash]
+----
+$ curl -u jdoe:password http://localhost:3000/api
+Namespaces: [default istio-system kube-public kube-system myproject openshift openshift-infra openshift-node]
+
+Namespace: default Services [docker-registry kubernetes router]
+
+Service Name: docker-registry
+Service Labels:
+docker-registry = default
+Type: ClusterIP
+...
+----
+
+WARNING: The proxy will only serve requests without the text/html accept header,
+using the browser directly won't work.
+
 == Production Builds
 Use `npm run build` which will bundle the build artifacts using webpack into the `build` directory.
 
@@ -33,7 +68,7 @@ Use `npm run build` which will bundle the build artifacts using webpack into the
 * `src/assets` : Images and other assets
 * `src/components` : Stateless components (pure functions)
 * `src/containers` : Stateful (smart) components
-* `src/hoc` : High rder Components
+* `src/hoc` : High order Components
 * `src/pages` : Top level pages and nested components
 * `stories`: Storybook files
 * `build`: Production build output


### PR DESCRIPTION
This PR has the configuration required to point to swscore inside openshift without having to do any tricky stuff (build swscore docker again, rsync, etc) while developing the UI.

We only have to add the `proxy` configuration [1] to our `package.json` and point it to our swscore endpoint.

# SwsCore inside openshift
## UI
![screenshot from 2018-02-21 12-39-33](https://user-images.githubusercontent.com/3845764/36498661-9963eea0-1704-11e8-8c94-ab5ecf582ec9.png)

## API
![screenshot from 2018-02-21 12-39-41](https://user-images.githubusercontent.com/3845764/36498660-9942f984-1704-11e8-8c65-a2e2fbb79bc0.png)

# SwsUI in development
![screenshot from 2018-02-21 12-40-47](https://user-images.githubusercontent.com/3845764/36498659-99254484-1704-11e8-92d6-1916b08c4576.png)

## API
![screenshot from 2018-02-21 12-46-15](https://user-images.githubusercontent.com/3845764/36498852-3fb293a6-1705-11e8-80b2-8a4d76f6dca9.png)


Notes: 
- We can't access the API by writing its URL on the browser, is because the proxy will only serve requests without the `text/html` accept header [2].
- This only works when running `npm start` so a production build is not affected.
- This can be further configured [3] if we need to access many endpoints from different URLs.

[1] https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#proxying-api-requests-in-development
[2] https://github.com/facebook/create-react-app/issues/1378#issuecomment-272182020
[3] https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#configuring-the-proxy-manually