### PR TITLE
SWS-128 Fix tsconfig compiler error messages

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",


### PR DESCRIPTION
These messages currently show up:
```
Failed to load tsconfig.json: Missing baseUrl in compilerOptions
Creating an optimized production build...
Found no baseUrl in tsconfig.json, not applying tsconfig-paths-webpack-plugin
Found no baseUrl in tsconfig.json, not applying tsconfig-paths-webpack-plugin
```

https://issues.jboss.org/browse/SWS-128
