### PR TITLE
Don't publish node modules to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ tsconfig.test.json
 tslint.json
 .idea
 .storybook
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "bugs": {
     "url": "https://issues.jboss.org/projects/SWS/issues/"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "bugs": {
     "url": "https://issues.jboss.org/projects/SWS/issues/"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "bugs": {
     "url": "https://issues.jboss.org/projects/SWS/issues/"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "bugs": {
     "url": "https://issues.jboss.org/projects/SWS/issues/"
   },


### PR DESCRIPTION
Don't publish the 300mb of `node_modules` to npm.

From the archive tarball it gets us down to about 7mb.

https://issues.jboss.org/browse/SWS-129

Required by: https://issues.jboss.org/browse/SWS-127