### PR TITLE
SWS-63: Preliminar mock for ServiceList page

### DIFF
--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -22,13 +22,13 @@ class Navigation extends React.Component {
           </li>
           <li className={this.itemClass('/service-graph')}>
             <Link to="/service-graph">
-              <span className="fa fa-shield" data-toggle="tooltip" title="Graph" />
+              <span className="fa pficon-topology" data-toggle="tooltip" title="Graph" />
               <span className="list-group-item-value">Graph</span>
             </Link>
           </li>
           <li className={this.itemClass('/services')}>
             <Link to="/services">
-              <span className="fa fa-users" data-toggle="tooltip" title="Services" />
+              <span className="fa pficon-service" data-toggle="tooltip" title="Services" />
               <span className="list-group-item-value">Services</span>
             </Link>
           </li>

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 type ServiceGraphState = {
   alertVisible: boolean;
 };
@@ -26,7 +25,7 @@ class ServiceGraphPage extends React.Component<ServiceGraphProps, ServiceGraphSt
     return (
       <div className="container-fluid container-pf-nav-pf-vertical">
         <div className="page-header">
-          <h2>Services Graph</h2>
+          <h2>Service Graph</h2>
         </div>
         <div className="App-body">
           <div className="App-intro">

--- a/src/pages/ServiceList/ServiceFilter.tsx
+++ b/src/pages/ServiceList/ServiceFilter.tsx
@@ -1,0 +1,209 @@
+import * as React from 'react';
+import { Filter, FormControl, Toolbar } from 'patternfly-react';
+
+type ServiceFilterValue = {
+  id: string;
+  title: string;
+};
+
+type ServiceFilterType = {
+  id: string;
+  title: string;
+  placeholder: string;
+  filterType: string;
+  filterValues: ServiceFilterValue[];
+};
+
+type ServiceFilterProps = {};
+
+type ActiveFilterType = {
+  label: string;
+};
+
+type ServiceFilterState = {
+  currentFilterType: ServiceFilterType;
+  activeFilters: ActiveFilterType[];
+  currentValue: string;
+};
+
+const demoFilters: ServiceFilterType[] = [
+  {
+    id: 'servicename',
+    title: 'Service Name',
+    placeholder: 'Filter by Service Name',
+    filterType: 'text',
+    filterValues: []
+  },
+  {
+    id: 'namespace',
+    title: 'Namespace',
+    placeholder: 'Filter by Namespace',
+    filterType: 'select',
+    filterValues: [
+      { title: 'istio-system', id: 'istio-system' },
+      { title: 'kubernetes', id: 'kubernetes' },
+      { title: 'default', id: 'default' },
+      { title: 'myproject', id: 'myproject' }
+    ]
+  }
+];
+
+class ServiceFilter extends React.Component<ServiceFilterProps, ServiceFilterState> {
+  constructor(props: ServiceFilterProps) {
+    super(props);
+
+    this.updateCurrentValue = this.updateCurrentValue.bind(this);
+    this.onValueKeyPress = this.onValueKeyPress.bind(this);
+    this.selectFilterType = this.selectFilterType.bind(this);
+    this.filterValueSelected = this.filterValueSelected.bind(this);
+    this.removeFilter = this.removeFilter.bind(this);
+    this.clearFilters = this.clearFilters.bind(this);
+
+    this.state = {
+      currentFilterType: demoFilters[0],
+      activeFilters: [],
+      currentValue: ''
+    };
+  }
+
+  filterAdded(field: any, value: any) {
+    let filterText = '';
+    if (field.title) {
+      filterText = field.title;
+    }
+    filterText += ': ';
+
+    if (value.filterCategory) {
+      filterText +=
+        (value.filterCategory.title || value.filterCategory) + '-' + (value.filterValue.title || value.filterValue);
+    } else if (value.title) {
+      filterText += value.title;
+    } else {
+      filterText += value;
+    }
+
+    let activeFilters = this.state.activeFilters;
+    activeFilters.push({ label: filterText });
+    this.setState({ activeFilters: activeFilters });
+  }
+
+  selectFilterType(filterType: ServiceFilterType) {
+    const { currentFilterType } = this.state;
+    if (currentFilterType !== filterType) {
+      this.setState({
+        currentValue: '',
+        currentFilterType: filterType
+      });
+    }
+  }
+
+  filterValueSelected(filterValue: ServiceFilterValue) {
+    const { currentFilterType, currentValue } = this.state;
+
+    if (filterValue && filterValue.id !== currentValue) {
+      this.filterAdded(currentFilterType, filterValue);
+    }
+  }
+
+  updateCurrentValue(event: any) {
+    this.setState({ currentValue: event.target.value });
+  }
+
+  onValueKeyPress(keyEvent: any) {
+    const { currentValue, currentFilterType } = this.state;
+
+    if (keyEvent.key === 'Enter' && currentValue && currentValue.length > 0) {
+      this.setState({ currentValue: '' });
+      this.filterAdded(currentFilterType, currentValue);
+      keyEvent.stopPropagation();
+      keyEvent.preventDefault();
+    }
+  }
+
+  removeFilter(filter: ActiveFilterType) {
+    const { activeFilters } = this.state;
+
+    let index = activeFilters.indexOf(filter);
+    if (index > -1) {
+      let updated = [...activeFilters.slice(0, index), ...activeFilters.slice(index + 1)];
+      this.setState({ activeFilters: updated });
+    }
+  }
+
+  clearFilters() {
+    this.setState({ activeFilters: [] });
+  }
+
+  renderInput() {
+    const { currentFilterType, currentValue } = this.state;
+    if (!currentFilterType) {
+      return null;
+    }
+
+    if (currentFilterType.filterType === 'select') {
+      return (
+        <Filter.ValueSelector
+          filterValues={currentFilterType.filterValues}
+          placeholder={currentFilterType.placeholder}
+          currentValue={currentValue}
+          onFilterValueSelected={this.filterValueSelected}
+        />
+      );
+    } else {
+      return (
+        <FormControl
+          type={currentFilterType.filterType}
+          value={currentValue}
+          placeholder={currentFilterType.placeholder}
+          onChange={e => this.updateCurrentValue(e)}
+          onKeyPress={e => this.onValueKeyPress(e)}
+        />
+      );
+    }
+  }
+
+  render() {
+    const { currentFilterType, activeFilters } = this.state;
+
+    return (
+      <div>
+        <div style={{ width: 300 }}>
+          <Filter>
+            <Filter.TypeSelector
+              filterTypes={demoFilters}
+              currentFilterType={currentFilterType}
+              onFilterTypeSelected={this.selectFilterType}
+            />
+            {this.renderInput()}
+          </Filter>
+        </div>
+        {activeFilters &&
+          activeFilters.length > 0 && (
+            <Toolbar.Results>
+              <Filter.ActiveLabel>{'Active Filters:'}</Filter.ActiveLabel>
+              <Filter.List>
+                {activeFilters.map((item, index) => {
+                  return (
+                    <Filter.Item key={index} onRemove={this.removeFilter} filterData={item}>
+                      {item.label}
+                    </Filter.Item>
+                  );
+                })}
+              </Filter.List>
+              <a
+                href="#"
+                onClick={e => {
+                  e.preventDefault();
+                  this.clearFilters();
+                }}
+              >
+                Clear All Filters
+              </a>
+            </Toolbar.Results>
+          )}
+      </div>
+    );
+  }
+}
+
+export default ServiceFilter;

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ListView, ListViewItem, ListViewIcon, Button } from 'patternfly-react';
+import { ListView, ListViewItem, ListViewIcon } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 
 class ServiceListComponent extends React.Component {
@@ -7,24 +7,58 @@ class ServiceListComponent extends React.Component {
     return (
       <div>
         <ListView>
-          <ListViewItem
-            key="Product Page"
-            leftContent={<ListViewIcon name="plane" />}
-            heading={
-              <span>
-                Product Page
-                <small>Feb 23, 2015 12:32 am</small>
-              </span>
-            }
-            actions={
-              <div>
-                <Link to={'/namespaces/istio-system/services/ProductPage'}>
-                  <Button>Details</Button>
-                </Link>
-              </div>
-            }
-            description={<span />}
-          />
+          <Link to={'/namespaces/istio-system/services/productpage'} style={{ color: 'black' }}>
+            <ListViewItem
+              key="productpage"
+              leftContent={<ListViewIcon type="pf" name="service" />}
+              heading={
+                <span>
+                  productpage
+                  <small>istio-system</small>
+                </span>
+              }
+              description={<span />}
+            />
+          </Link>
+          <Link to={'/namespaces/istio-system/services/reviews'} style={{ color: 'black' }}>
+            <ListViewItem
+              key="reviews"
+              leftContent={<ListViewIcon type="pf" name="service" />}
+              heading={
+                <span>
+                  reviews
+                  <small>istio-system</small>
+                </span>
+              }
+              description={<span />}
+            />
+          </Link>
+          <Link to={'/namespaces/istio-system/services/ratings'} style={{ color: 'black' }}>
+            <ListViewItem
+              key="ratings"
+              leftContent={<ListViewIcon type="pf" name="service" />}
+              heading={
+                <span>
+                  ratings
+                  <small>istio-system</small>
+                </span>
+              }
+              description={<span />}
+            />
+          </Link>
+          <Link to={'/namespaces/istio-system/services/details'} style={{ color: 'black' }}>
+            <ListViewItem
+              key="details"
+              leftContent={<ListViewIcon type="pf" name="service" />}
+              heading={
+                <span>
+                  details
+                  <small>istio-system</small>
+                </span>
+              }
+              description={<span />}
+            />
+          </Link>
         </ListView>
       </div>
     );

--- a/src/pages/ServiceList/ServiceListPage.tsx
+++ b/src/pages/ServiceList/ServiceListPage.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import ServiceListComponent from './ServiceListComponent';
+import ServiceFilter from './ServiceFilter';
+import ServicePagination from './ServicePagination';
 
 type ServiceListState = {
   alertVisible: boolean;
@@ -26,10 +28,10 @@ class ServiceListPage extends React.Component<ServiceListProps, ServiceListState
   render() {
     return (
       <div className="container-fluid container-pf-nav-pf-vertical">
-        <div className="page-header">
-          <h2>Services</h2>
-        </div>
+        <h2>Services</h2>
+        <ServiceFilter />
         <ServiceListComponent />
+        <ServicePagination />
       </div>
     );
   }

--- a/src/pages/ServiceList/ServicePagination.tsx
+++ b/src/pages/ServiceList/ServicePagination.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { Paginator } from 'patternfly-react';
+
+type ServicePaginationProps = {};
+
+const demoPagination = { page: 1, perPage: 10, perPageOptions: [5, 10, 15] };
+const demoMessages = {
+  firstPage: 'First Page',
+  previousPage: 'Previous Page',
+  currentPage: 'Current Page'
+};
+
+class ServicePagination extends React.Component<ServicePaginationProps> {
+  constructor(props: ServicePaginationProps) {
+    super(props);
+    this.onPageSet = this.onPageSet.bind(this);
+    this.onPageSelect = this.onPageSelect.bind(this);
+  }
+
+  onPageSet(e: any) {
+    console.log('onPageSet ' + e);
+  }
+
+  onPageSelect(e: any) {
+    console.log('onPageSelect ' + e);
+  }
+
+  render() {
+    return (
+      <div>
+        <Paginator
+          viewType="list"
+          pagination={demoPagination}
+          itemCount={75}
+          onPageSet={this.onPageSet}
+          onPerPageSelect={this.onPageSelect}
+          messages={demoMessages}
+        />
+      </div>
+    );
+  }
+}
+
+export default ServicePagination;


### PR DESCRIPTION
- Changed proper icons on navigation and service
- Introduce basic features proposed for service list: filtering and paging
- This is pure mock with demo data, no connectivity with backend

I wanted to split SWS-63 in two parts, this is just a mock data showing the visual elements we are going to add, following PR will complete the connectivity with real backend calls, but to not send a big PR, I guess it's better to propose this way (note. I will ruse same JIRA code for next commit).

So, this page shows the list of services and will provide basic filtering by namespace or service name and also a basic pagination (as we don't know how many services we will have).

Also, in the list we can anticipate some info from the details, i.e. summary of pods, versions, istio rules, or even some mini graph. These is just food to thing for following sprints on planning phase.

The goal for Sprint 1 should be to make this works end-to-end.

This is a snapshot

![image](https://user-images.githubusercontent.com/1662329/36590912-839930de-1890-11e8-9d1b-b42864683603.png)

React components are not definitive, just to put the elements in place, in the following PR once backend is connected those will be re-organized to share state correctly.