### PR TITLE
SWS-131 change homepage (= base url) to /

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
   ],
   "author": "Red Hat",
   "license": "Apache-2.0",
-  "homepage": "."
+  "homepage": "/"
 }


### PR DESCRIPTION
This is to enable client-side routing. Else HTML contains links such as "/services/static/js/main.f06a050d.js" instead of "/static/js/main.f06a050d.js" when hitting url "http://sws.../services"