### PR TITLE
Add Cytoscape layout for the Service Graph page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3720,6 +3720,31 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "cytoscape": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.2.9.tgz",
+      "integrity": "sha512-BqYJsq1Q3Bm5A/fk9nRAcF6bOdQOyo5ko+NEvh8ufAylCG6Vx3jtZu3G4CXr14b+7VlpSC8a3kA6+rd6LX+EBQ==",
+      "requires": {
+        "heap": "0.2.6",
+        "lodash.debounce": "4.0.8"
+      }
+    },
+    "cytoscape-cola": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.1.0.tgz",
+      "integrity": "sha512-NhRolioV6y/9OnIztsE1km2ueXGhXXpIKqkO+aCQoDMACC+NhSRI5o2ddjs86G46hx2cNV0+eUk86UJMeBtprA==",
+      "requires": {
+        "webcola": "3.3.8"
+      }
+    },
+    "cytoscape-dagre": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.2.0.tgz",
+      "integrity": "sha512-7i9OtzDtMlo9aqZxAJkXHYvwLrq224wDq6W7D9y4hill2X91pxBGHfv2lQxgzxL5fcDFsVyxVBuqpeXeoWzN1A==",
+      "requires": {
+        "dagre": "0.7.4"
+      }
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -3732,6 +3757,46 @@
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
       "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+    },
+    "d3-dispatch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
+      "integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg="
+    },
+    "d3-drag": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
+      "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
+      "requires": {
+        "d3-dispatch": "1.0.3",
+        "d3-selection": "1.3.0"
+      }
+    },
+    "d3-selection": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.0.tgz",
+      "integrity": "sha512-qgpUOg9tl5CirdqESUAu0t9MU/t3O9klYfGfyKsXEmhyxyzLpzpeh08gaxBUTQw1uXIOkr/30Ut2YRjSSxlmHA=="
+    },
+    "d3-timer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.7.tgz",
+      "integrity": "sha512-vMZXR88XujmG/L5oB96NNKH5lCWwiLM/S2HyyAQLcjWJCloK5shxta4CwOFYLZoY3AWX73v8Lgv4cCAdWtRmOA=="
+    },
+    "dagre": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.7.4.tgz",
+      "integrity": "sha1-3nLw50pVDOEc5jjwoTb+1xI5gCI=",
+      "requires": {
+        "graphlib": "1.0.7",
+        "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -5856,6 +5921,21 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "graphlib": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-1.0.7.tgz",
+      "integrity": "sha1-DKst8P/mq+BwsmJb+h7bbslnuLE=",
+      "requires": {
+        "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -6004,6 +6084,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "history": {
       "version": "4.7.2",
@@ -7783,8 +7868,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -10978,6 +11062,17 @@
         "c3": "0.4.21"
       }
     },
+    "react-cytoscape": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/react-cytoscape/-/react-cytoscape-1.0.6.tgz",
+      "integrity": "sha512-bCBLyctKVDuxe9W2b/TaBGwk+Q1/AX33k+ocD94r0Pq4KQGAJNS91m3Z/czSOkDHcK1VmbImxnH2Q75J5lxeiQ==",
+      "requires": {
+        "cytoscape": "3.2.9",
+        "cytoscape-cola": "2.1.0",
+        "cytoscape-dagre": "2.2.0",
+        "fsevents": "1.1.2"
+      }
+    },
     "react-dev-utils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-4.2.1.tgz",
@@ -13347,6 +13442,16 @@
       "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
       "requires": {
         "minimalistic-assert": "1.0.0"
+      }
+    },
+    "webcola": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.3.8.tgz",
+      "integrity": "sha512-WVDTdHS1SaqYCUJGPdbOhqj44mchDyTC78tozUdqJllwYeJ2554+BWkJfc5kNphT8foip2StCMw1FWsIvGmv9w==",
+      "requires": {
+        "d3-dispatch": "1.0.3",
+        "d3-drag": "1.2.1",
+        "d3-timer": "1.0.7"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prettier": "^1.10.2",
     "react": "~16.2.0",
     "react-bootstrap": "~0.32.1",
+    "react-cytoscape": "^1.0.6",
     "react-dom": "~16.2.0",
     "react-router-dom": "^4.2.2",
     "react-scripts-ts": "2.13.0"

--- a/src/pages/ServiceGraph/CytoscapeConfig.ts
+++ b/src/pages/ServiceGraph/CytoscapeConfig.ts
@@ -1,0 +1,48 @@
+export class CytoscapeConfig {
+  static getStyles() {
+    return [
+      {
+        selector: 'node',
+        style: {
+          width: 300,
+          height: 300,
+          content: 'data(label)',
+          //          'text-opacity': 0.5,
+          'text-valign': 'center',
+          color: 'white',
+          'background-color': '#bbb',
+          'text-outline-width': 2,
+          'text-outline-color': '#999'
+        }
+      },
+
+      {
+        selector: 'edge',
+        style: {
+          width: 10,
+          content: 'data(label)',
+          'target-arrow-shape': 'triangle',
+          'line-color': 'data(color)',
+          'target-arrow-color': '#9dbaea'
+        }
+      },
+
+      {
+        selector: ':selected',
+        style: {
+          'background-color': 'yellow',
+          'line-color': 'yellow',
+          'target-arrow-color': 'black',
+          'source-arrow-color': 'black'
+        }
+      },
+
+      {
+        selector: 'edge:selected',
+        style: {
+          width: 20
+        }
+      }
+    ];
+  }
+}

--- a/src/pages/ServiceGraph/CytoscapeConfig.ts
+++ b/src/pages/ServiceGraph/CytoscapeConfig.ts
@@ -3,44 +3,48 @@ export class CytoscapeConfig {
     return [
       {
         selector: 'node',
-        style: {
-          width: 300,
-          height: 300,
-          content: 'data(label)',
-          //          'text-opacity': 0.5,
-          'text-valign': 'center',
+        css: {
+          content: function(ele: any) {
+            return ele.data('text') || ele.data('id');
+          },
           color: 'white',
           'background-color': '#bbb',
-          'text-outline-width': 2,
-          'text-outline-color': '#999'
+          'text-outline-width': 1,
+          'text-outline-color': '#999',
+          'text-valign': 'center',
+          'text-halign': 'center'
         }
       },
-
+      {
+        selector: '$node > node',
+        css: {
+          'padding-top': '10px',
+          'padding-left': '10px',
+          'padding-bottom': '10px',
+          'padding-right': '10px',
+          color: '#070dff',
+          'text-valign': 'top',
+          'text-halign': 'center',
+          'background-color': '#f5f1d8'
+        }
+      },
       {
         selector: 'edge',
-        style: {
-          width: 10,
-          content: 'data(label)',
+        css: {
+          width: 2,
+          content: 'data(text)',
           'target-arrow-shape': 'triangle',
           'line-color': 'data(color)',
-          'target-arrow-color': '#9dbaea'
+          'target-arrow-color': 'black'
         }
       },
-
       {
         selector: ':selected',
-        style: {
+        css: {
           'background-color': 'yellow',
           'line-color': 'yellow',
-          'target-arrow-color': 'black',
-          'source-arrow-color': 'black'
-        }
-      },
-
-      {
-        selector: 'edge:selected',
-        style: {
-          width: 20
+          'target-arrow-color': 'yellow',
+          'source-arrow-color': 'yellow'
         }
       }
     ];

--- a/src/pages/ServiceGraph/FakeData.ts
+++ b/src/pages/ServiceGraph/FakeData.ts
@@ -1,0 +1,138 @@
+// This class has some static Fake data in cytoscape format
+// This is just temporary until real data from backend is hooked up
+// It is very useful for tweaking the data and retesting
+export class FakeData {
+  static getElements() {
+    return {
+      nodes: [
+        {
+          data: {
+            id: 'n0',
+            service: 'productpage.istio-system.svc.cluster.local',
+            version: 'v1',
+            label: 'productpage (v1)',
+            link_prom_graph:
+              'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22productpage.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D'
+          }
+        },
+        {
+          data: {
+            id: 'n1',
+            service: 'reviews.istio-system.svc.cluster.local',
+            version: 'v2',
+            label: 'reviews (v2)',
+            parent: 'n6',
+            link_prom_graph:
+              'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v2%22%7D'
+          }
+        },
+        {
+          data: {
+            id: 'n2',
+            service: 'ratings.istio-system.svc.cluster.local',
+            version: 'v1',
+            label: 'ratings (v1)',
+            link_prom_graph:
+              'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22ratings.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D'
+          }
+        },
+        {
+          data: {
+            id: 'n3',
+            service: 'reviews.istio-system.svc.cluster.local',
+            version: 'v3',
+            label: 'reviews (v3)',
+            parent: 'n6',
+            link_prom_graph:
+              'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v3%22%7D'
+          }
+        },
+        {
+          data: {
+            id: 'n4',
+            service: 'details.istio-system.svc.cluster.local',
+            version: 'v1',
+            label: 'details (v1)',
+            link_prom_graph:
+              'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22details.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D'
+          }
+        },
+        {
+          data: {
+            id: 'n5',
+            service: 'reviews.istio-system.svc.cluster.local',
+            version: 'v1',
+            label: 'reviews (v1)',
+            parent: 'n6',
+            link_prom_graph:
+              'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D'
+          }
+        },
+        {
+          data: {
+            id: 'n6',
+            service: 'reviews.istio-system.svc.cluster.local',
+            label: 'reviews',
+            color: '#bbb'
+          }
+        }
+      ],
+      edges: [
+        {
+          data: {
+            id: 'e0',
+            source: 'n0',
+            target: 'n1',
+            label: 'rpm=0',
+            color: 'black'
+          }
+        },
+        {
+          data: {
+            id: 'e1',
+            source: 'n1',
+            target: 'n2',
+            label: 'rpm=0.7',
+            color: 'orange'
+          }
+        },
+        {
+          data: {
+            id: 'e2',
+            source: 'n0',
+            target: 'n3',
+            label: 'rpm=0',
+            color: 'black'
+          }
+        },
+        {
+          data: {
+            id: 'e3',
+            source: 'n3',
+            target: 'n2',
+            label: 'rpm=0',
+            color: 'black'
+          }
+        },
+        {
+          data: {
+            id: 'e4',
+            source: 'n0',
+            target: 'n4',
+            label: 'rpm=0',
+            color: 'black'
+          }
+        },
+        {
+          data: {
+            id: 'e5',
+            source: 'n0',
+            target: 'n5',
+            label: 'rpm=0',
+            color: 'black'
+          }
+        }
+      ]
+    };
+  }
+}

--- a/src/pages/ServiceGraph/FakeData.ts
+++ b/src/pages/ServiceGraph/FakeData.ts
@@ -10,7 +10,7 @@ export class FakeData {
             id: 'n0',
             service: 'productpage.istio-system.svc.cluster.local',
             version: 'v1',
-            label: 'productpage (v1)',
+            text: 'productpage (v1)',
             link_prom_graph:
               'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22productpage.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D'
           }
@@ -20,7 +20,7 @@ export class FakeData {
             id: 'n1',
             service: 'reviews.istio-system.svc.cluster.local',
             version: 'v2',
-            label: 'reviews (v2)',
+            text: 'reviews (v2)',
             parent: 'n6',
             link_prom_graph:
               'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v2%22%7D'
@@ -31,7 +31,7 @@ export class FakeData {
             id: 'n2',
             service: 'ratings.istio-system.svc.cluster.local',
             version: 'v1',
-            label: 'ratings (v1)',
+            text: 'ratings (v1)',
             link_prom_graph:
               'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22ratings.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D'
           }
@@ -41,7 +41,7 @@ export class FakeData {
             id: 'n3',
             service: 'reviews.istio-system.svc.cluster.local',
             version: 'v3',
-            label: 'reviews (v3)',
+            text: 'reviews (v3)',
             parent: 'n6',
             link_prom_graph:
               'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v3%22%7D'
@@ -52,7 +52,7 @@ export class FakeData {
             id: 'n4',
             service: 'details.istio-system.svc.cluster.local',
             version: 'v1',
-            label: 'details (v1)',
+            text: 'details (v1)',
             link_prom_graph:
               'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22details.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D'
           }
@@ -62,7 +62,7 @@ export class FakeData {
             id: 'n5',
             service: 'reviews.istio-system.svc.cluster.local',
             version: 'v1',
-            label: 'reviews (v1)',
+            text: 'reviews (v1)',
             parent: 'n6',
             link_prom_graph:
               'http://prometheus:9090/graph?g0.range_input=1h&g0.tab=0&g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D'
@@ -72,7 +72,7 @@ export class FakeData {
           data: {
             id: 'n6',
             service: 'reviews.istio-system.svc.cluster.local',
-            label: 'reviews',
+            text: 'reviews',
             color: '#bbb'
           }
         }
@@ -83,7 +83,7 @@ export class FakeData {
             id: 'e0',
             source: 'n0',
             target: 'n1',
-            label: 'rpm=0',
+            text: 'rpm=0',
             color: 'black'
           }
         },
@@ -92,7 +92,7 @@ export class FakeData {
             id: 'e1',
             source: 'n1',
             target: 'n2',
-            label: 'rpm=0.7',
+            text: 'rpm=0.7',
             color: 'orange'
           }
         },
@@ -101,7 +101,7 @@ export class FakeData {
             id: 'e2',
             source: 'n0',
             target: 'n3',
-            label: 'rpm=0',
+            text: 'rpm=0',
             color: 'black'
           }
         },
@@ -110,7 +110,7 @@ export class FakeData {
             id: 'e3',
             source: 'n3',
             target: 'n2',
-            label: 'rpm=0',
+            text: 'rpm=0',
             color: 'black'
           }
         },
@@ -119,7 +119,7 @@ export class FakeData {
             id: 'e4',
             source: 'n0',
             target: 'n4',
-            label: 'rpm=0',
+            text: 'rpm=0',
             color: 'black'
           }
         },
@@ -128,7 +128,7 @@ export class FakeData {
             id: 'e5',
             source: 'n0',
             target: 'n5',
-            label: 'rpm=0',
+            text: 'rpm=0',
             color: 'black'
           }
         }

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
+import { ReactCytoscape } from 'react-cytoscape';
+import { FakeData } from './FakeData';
+import { CytoscapeConfig } from './CytoscapeConfig';
+
 type ServiceGraphState = {
-  alertVisible: boolean;
+  elements?: any;
 };
 
 type ServiceGraphProps = {
@@ -8,29 +12,48 @@ type ServiceGraphProps = {
 };
 
 class ServiceGraphPage extends React.Component<ServiceGraphProps, ServiceGraphState> {
+  cy: any;
+
   constructor(props: ServiceGraphProps) {
     super(props);
 
     console.log('Starting ServiceGraphPage');
+
     this.state = {
-      alertVisible: true
+      elements: {}
     };
   }
 
-  dismissSuccess() {
-    this.setState({ alertVisible: false });
+  componentDidMount() {
+    this.setState({ elements: FakeData.getElements() });
+  }
+
+  cyRef(cy: any) {
+    this.cy = cy;
+    cy.on('tap', 'node', function(evt: any) {
+      let node = evt.target;
+      console.dir(node);
+      console.log('clicked on: ' + node.id());
+    });
   }
 
   render() {
     return (
       <div className="container-fluid container-pf-nav-pf-vertical">
         <div className="page-header">
-          <h2>Service Graph</h2>
+          <h2>Services Graph</h2>
         </div>
-        <div className="App-body">
-          <div className="App-intro">
-            <h2>Services Graph Page</h2>
-          </div>
+        <div style={{ height: 600 }}>
+          <ReactCytoscape
+            containerID="cy"
+            cyRef={cy => {
+              this.cyRef(cy);
+            }}
+            elements={this.state.elements}
+            style={CytoscapeConfig.getStyles()}
+            cytoscapeOptions={{ wheelSensitivity: 0.1, autounselectify: false }}
+            layout={{ name: 'dagre' }}
+          />
         </div>
       </div>
     );


### PR DESCRIPTION
Preliminary Service Graph with Cytoscape

![image](https://user-images.githubusercontent.com/1312165/36624234-6f07b560-18c1-11e8-8bf5-57222fcbcc91.png)

https://issues.jboss.org/browse/SWS-73

Next steps to hook up to Jay's live data (we have already agreed on a cytoscape data format to send).
Still need to tweak look-n-feel more, add namespace selection and linking to other screens.