### PR TITLE
SWS-131: prefix all client routes with /console

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,7 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 class App extends React.Component {
   render() {
     return (
-      <BrowserRouter>
+      <BrowserRouter basename="/console">
         <div>
           <Navigation />
         </div>


### PR DESCRIPTION
Needs https://github.com/swift-sunshine/swscore/pull/64 on server side
PS: for motivations, see discussion on server-side PR