### PR TITLE
[SWS-150] Have the service graph fill all the whitespace

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,8 @@ body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
+
+  height: 100vh;
 }
 
 .left-spinner {

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -26,6 +26,9 @@ class ServiceGraphPage extends React.Component<ServiceGraphProps, ServiceGraphSt
 
   componentDidMount() {
     this.setState({ elements: FakeData.getElements() });
+
+    window.addEventListener('resize', this.resizeWindow);
+    this.resizeWindow();
   }
 
   cyRef(cy: any) {
@@ -37,13 +40,22 @@ class ServiceGraphPage extends React.Component<ServiceGraphProps, ServiceGraphSt
     });
   }
 
+  resizeWindow() {
+    let canvasWrapper = document.getElementById('cytoscope-container')!;
+
+    if (canvasWrapper != null) {
+      let dimensions = canvasWrapper.getBoundingClientRect();
+      canvasWrapper.style.height = `${document.documentElement.scrollHeight - dimensions.top}px`;
+    }
+  }
+
   render() {
     return (
       <div className="container-fluid container-pf-nav-pf-vertical">
         <div className="page-header">
           <h2>Services Graph</h2>
         </div>
-        <div style={{ height: 600 }}>
+        <div id="cytoscope-container">
           <ReactCytoscape
             containerID="cy"
             cyRef={cy => {


### PR DESCRIPTION
This defines the logic for scaling the service graph canvas on the page,
and recomputing it on resize.

Fixes: https://issues.jboss.org/browse/SWS-150