### PR TITLE
SWS-150 Fill the whitespace in the service graph page.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.7",
+  "version": "0.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swsui",
-  "version": "0.2.7",
+  "version": "0.2.10",
   "bugs": {
     "url": "https://issues.jboss.org/projects/SWS/issues/"
   },

--- a/src/components/CytoscapeLayout/CytoscapeLayout.tsx
+++ b/src/components/CytoscapeLayout/CytoscapeLayout.tsx
@@ -25,7 +25,19 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
     };
   }
 
+  resizeWindow() {
+    let canvasWrapper = document.getElementById('cytoscape-container')!;
+
+    if (canvasWrapper != null) {
+      let dimensions = canvasWrapper.getBoundingClientRect();
+      canvasWrapper.style.height = `${document.documentElement.scrollHeight - dimensions.top}px`;
+    }
+  }
+
   componentDidMount() {
+    window.addEventListener('resize', this.resizeWindow);
+    this.resizeWindow();
+
     API.GetGraphElements(this.props.namespace, null)
       .then(response => {
         const elements: { [key: string]: any } = response['data'];
@@ -42,14 +54,13 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
     this.cy = cy;
     cy.on('tap', 'node', (evt: any) => {
       let node = evt.target;
-      console.dir(node);
       console.log('clicked on: ' + node.id());
     });
   }
 
   render() {
     return (
-      <div style={{ height: 600 }}>
+      <div id="cytoscape-container">
         <ReactCytoscape
           containerID="cy"
           cyRef={cy => {


### PR DESCRIPTION
This is just adding back in a feature that got removed because the file structures had changed so much it wasn't possible to merge.
This is @cfcosta work from commit: b89fde7ea014d00d09b8edbf76e5336db234149e

Video: https://www.dropbox.com/s/6l3km3buwfzxtgn/cytoscrape-resize.mov?dl=0