### PR TITLE
SWS 115 - Uses npm-snapshot to have a snapshot version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ script:
     npm test -- --coverage
 after_success:
   - cat ./coverage/lcov.info | coveralls
+before_deploy:
+  - npm run set-snapshot-version $TRAVIS_BUILD_NUMBER
 deploy:
   provider: npm
   email: jmartine@redhat.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -8982,6 +8982,12 @@
         "path-key": "2.0.1"
       }
     },
+    "npm-snapshot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/npm-snapshot/-/npm-snapshot-1.0.3.tgz",
+      "integrity": "sha1-GJMK6onR3YyO1aJWcRBoodqvfA8=",
+      "dev": true
+    },
     "npm-which": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test": "npm run prettier && react-scripts-ts test --env=jsdom",
     "eject": "react-scripts-ts eject",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "set-snapshot-version": "npm-snapshot"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.3.12",
@@ -50,6 +51,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "node-sass-chokidar": "0.0.3",
+    "npm-snapshot": "^1.0.3",
     "typescript": "~2.7.1"
   },
   "sassIncludes": {


### PR DESCRIPTION
  NPM doesn't accept to upload the same version, we need to bump it.
  Manually bumping the version would be hard, and automatically doing so
  would require committing that package.json.
  npm-snapshot sets the version to ${VERSION}-snapshot.${input} and we
  are using $TRAVIS_BUILD_NUMBER as input.