### PR TITLE
SWS 115 - Skips cleanup and fixes request message ($TRAVIS_COMMIT)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ after_success:
 before_deploy:
   - npm run set-snapshot-version $TRAVIS_BUILD_NUMBER
 deploy:
+  skip_cleanup: true
   provider: npm
   email: jmartine@redhat.com
   api_key:
@@ -22,9 +23,7 @@ deploy:
     branch: master
     repo: swift-sunshine/swsui
 after_deploy:
-- 'curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json"
-  -H "Travis-API-Version: 3" -H "Authorization: token $TRAVIS_TOKEN" -d ''{"request":{"message":
-  "Triggered by swsui change: $TRAVIS_COMMIT", "branch":"master"}}'' https://api.travis-ci.org/repo/swift-sunshine%2Fswscore/requests'
+- 'curl -s -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Travis-API-Version: 3" -H "Authorization: token $TRAVIS_TOKEN" -d "{\"request\":{\"message\": \"Triggered by swsui change: $TRAVIS_COMMIT\", \"branch\":\"master\"}}" https://api.travis-ci.org/repo/swift-sunshine%2Fswscore/requests'
 env:
   global:
     secure: aI1uMj0h6xjzp2Xl8VeG4Eibnmz77OaTs8vYyOwgf4L5eN59Rz21oJE4j4AFkDBELUJvYHJix/EKWoIGszDFN/XCoOcB39h9MFyrHT74dwmjH1CHDg97e8KZU8oKpvpJ6D5c1tYUrbuzeK+pxqGptMi3zi9Cx8UpN9CavVa1QkcfEf0VfVdGpHIf+EbP9imEnArfPkUMfx0Schp761gySOvgtzzjIUwFLrrszSWM5s5KA8Z2BWMKN4877uey2HCYqfju9TrjWv396QxWxdnzqGvTQCO5jabcxSuK3N5IC76mlkuT/w0rxHVwULDU9JyBQo6gYGkHavKq5vvTOrWzEZwhL5mY6RvCwPg4GJma+O6DWZQRLEbF18Ubu2pm8BbLp+EUdgQMN+rBhTcbhX/om+tZkyODoVmxSEibSo6LcDJ3ZiS8pzlFVQiUbQ3wiQqcIPoDwlhhahwUutd35zt26HJvSs4HuRZ1R6TU3xtsHFVQULbIOMWcWd5dFnzTdBJW3aNu45vkWOE7wtANiAKmpkFowq0lRoKj6GdHgDEk9L0xy/QmoiCmCnrqtSsIill0GjmPpXWzIBQmS4uPUkjGveIqIGfrRqnSyRa6+f0wY4GQ0vkbF4DFbCTvRVcfvvph2R3MS/Tjhvt5L5Bhw52lg/DiWib2Synle1WyIjhXTLk=


### PR DESCRIPTION
Travis is doing a cleanup before publishing and that is interfering with npm-snapshot
```
Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment/#Uploading-Files.
```