### PR TITLE
SWS-182 Improve layouting

### DIFF
--- a/src/components/CytoscapeLayout/CytoscapeLayout.tsx
+++ b/src/components/CytoscapeLayout/CytoscapeLayout.tsx
@@ -72,7 +72,8 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
           layout={{
             name: 'breadthfirst',
             directed: 'true',
-            maximalAdjustments: 1
+            maximalAdjustments: 2,
+            spacingFactor: 1
           }}
         />
       </div>


### PR DESCRIPTION
Before this change. the details node would sometimes be placed into the 'reviews' box.
The change tells the layout engine to make adjustments after the first round. 
Also the spacing factor has been reduced so that nodes are closer together.
Now with this change:

![bildschirmfoto 2018-03-01 um 09 21 06](https://user-images.githubusercontent.com/208246/36834078-f3139b98-1d31-11e8-8419-56c2bf68e91e.png)


https://issues.jboss.org/browse/SWS-182

See also #65 for some changes to coloring.