### PR TITLE
SWS-187: Fix unused navigation entry

### DIFF
--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -7,8 +7,6 @@ import ServiceDetailsPage from '../../pages/ServiceDetails/ServiceDetailsPage';
 import ServiceGraphPage from '../../pages/ServiceGraph/ServiceGraphPage';
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
 
-const homePath = '/';
-const homeTitle = 'Overview';
 const serviceGraphPath = '/service-graph/istio-system';
 const serviceGraphTitle = 'Graph';
 const servicesPath = '/services';
@@ -28,12 +26,10 @@ class Navigation extends React.Component {
   }
 
   navigateTo(e: any) {
-    if (e.title === serviceGraphTitle) {
-      this.context.router.history.push(serviceGraphPath);
-    } else if (e.title === servicesTitle) {
+    if (e.title === servicesTitle) {
       this.context.router.history.push(servicesPath);
     } else {
-      this.context.router.history.push(homePath);
+      this.context.router.history.push(serviceGraphPath);
     }
   }
 
@@ -45,12 +41,11 @@ class Navigation extends React.Component {
             <VerticalNav.Brand iconImg={pfLogo} titleImg={pfBrand} />
           </VerticalNav.Masthead>
           <VerticalNav.Item
-            title={homeTitle}
-            iconClass="fa fa-dashboard"
+            title={serviceGraphTitle}
+            iconClass="fa pficon-topology"
             onClick={this.navigateTo}
             initialActive={true}
           />
-          <VerticalNav.Item title={serviceGraphTitle} iconClass="fa pficon-topology" onClick={this.navigateTo} />
           <VerticalNav.Item title={servicesTitle} iconClass="fa pficon-service" onClick={this.navigateTo} />
         </VerticalNav>
         <Switch>


### PR DESCRIPTION
- Select Graph as default one

As Home page is removed, Overview entry in navigation should be removed as well, it was creating some errors.
Now default page is Graph.

![image](https://user-images.githubusercontent.com/1662329/36842785-0bf7ecb6-1d4d-11e8-9d68-1319de3bfb71.png)
