### PR TITLE
SWS-165: Add namespace selector to service graph

### DIFF
--- a/src/components/CytoscapeLayout/CytoscapeLayout.tsx
+++ b/src/components/CytoscapeLayout/CytoscapeLayout.tsx
@@ -21,7 +21,7 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
     console.log('Starting ServiceGraphPage for namespace ' + this.props.namespace);
 
     this.state = {
-      elements: {}
+      elements: []
     };
   }
 
@@ -37,17 +37,15 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
   componentDidMount() {
     window.addEventListener('resize', this.resizeWindow);
     this.resizeWindow();
+    if (this.props.namespace.length !== 0) {
+      this.updateGraphElements(this.props.namespace);
+    }
+  }
 
-    API.GetGraphElements(this.props.namespace, null)
-      .then(response => {
-        const elements: { [key: string]: any } = response['data'];
-        console.log(elements);
-        this.setState(elements);
-      })
-      .catch(error => {
-        this.setState({});
-        console.error(error);
-      });
+  componentWillReceiveProps(nextProps: CytoscapeLayoutProps) {
+    if (nextProps.namespace !== this.props.namespace) {
+      this.updateGraphElements(nextProps.namespace);
+    }
   }
 
   cyRef(cy: any) {
@@ -78,5 +76,18 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
         />
       </div>
     );
+  }
+
+  private updateGraphElements(newNamespace: string) {
+    API.GetGraphElements(newNamespace, null)
+      .then(response => {
+        const elements: { [key: string]: any } = response['data'];
+        console.log(elements);
+        this.setState(elements);
+      })
+      .catch(error => {
+        this.setState({});
+        console.error(error);
+      });
   }
 }

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -1,19 +1,71 @@
 import * as React from 'react';
+import * as API from '../../services/Api';
 import { RouteComponentProps } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import NamespaceId from '../../types/NamespaceId';
 import CytoscapeLayout from '../../components/CytoscapeLayout/CytoscapeLayout';
+import { DropdownButton, MenuItem } from 'patternfly-react';
 
-export default function ServiceGraphPage(routeProps: RouteComponentProps<NamespaceId>) {
-  const namespace = routeProps.match.params.namespace;
+type ServiceGraphPageProps = {
+  availableNamespaces: { name: string }[];
+  graphNamespace: string;
+};
 
-  return (
-    <div className="container-fluid container-pf-nav-pf-vertical">
-      <div className="page-header">
-        <h2>Services Graph for namespace: {namespace} </h2>
+export default class ServiceGraphPage extends React.Component<RouteComponentProps<NamespaceId>, ServiceGraphPageProps> {
+  static contextTypes = {
+    router: PropTypes.object
+  };
+
+  constructor(routeProps: RouteComponentProps<NamespaceId>) {
+    super(routeProps);
+    this.namespaceSelected = this.namespaceSelected.bind(this);
+
+    this.state = {
+      availableNamespaces: [],
+      graphNamespace: routeProps.match.params.namespace
+    };
+
+    this.populateNamespacesSelect = this.populateNamespacesSelect.bind(this);
+  }
+
+  componentDidMount() {
+    API.GetNamespaces().then(this.populateNamespacesSelect);
+  }
+
+  componentWillReceiveProps(nextProps: RouteComponentProps<NamespaceId>) {
+    this.setState({ graphNamespace: nextProps.match.params.namespace });
+  }
+
+  populateNamespacesSelect(response: any) {
+    this.setState({ availableNamespaces: response['data'] });
+  }
+
+  namespaceSelected(selectedNamespace: string) {
+    this.context.router.history.push(`/service-graph/${selectedNamespace}`);
+  }
+
+  render() {
+    return (
+      <div className="container-fluid container-pf-nav-pf-vertical">
+        <div className="page-header">
+          <h2>
+            Services Graph for namespace:&nbsp;
+            <DropdownButton
+              id="namespace-selector"
+              title={this.state.graphNamespace}
+              onSelect={this.namespaceSelected}
+              bsSize="large"
+            >
+              {this.state.availableNamespaces.map(ns => (
+                <MenuItem key={ns.name} active={ns.name === this.state.graphNamespace} eventKey={ns.name}>
+                  {ns.name}
+                </MenuItem>
+              ))}
+            </DropdownButton>
+          </h2>
+        </div>
+        <CytoscapeLayout namespace={this.state.graphNamespace} />
       </div>
-      <div style={{ height: 600 }}>
-        <CytoscapeLayout namespace={namespace} />
-      </div>
-    </div>
-  );
+    );
+  }
 }

--- a/src/types/NamespaceId.ts
+++ b/src/types/NamespaceId.ts
@@ -1,5 +1,5 @@
 interface NamespaceId {
-  namespace: String;
+  namespace: string;
 }
 
 export default NamespaceId;


### PR DESCRIPTION
Namespace selector is a Patternfly dropdown. It is placed in the header,
replacing the namespace text.

![image](https://user-images.githubusercontent.com/23639005/36861176-cb4ba936-1d48-11e8-8900-48bfdae71eaf.png)
