### PR TITLE
SWS-199: Unify labels style in service details page

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfo.tsx
@@ -192,8 +192,6 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
                         let nNamespace = dependency.indexOf('.');
                         let servicename = dependency.substring(0, nNamespace);
                         let namespace = dependency.substring(nNamespace + 1, nVersion);
-                        console.log('SERVICENAME ' + servicename);
-                        console.log('NAMESPACE ' + namespace);
                         if (servicename.length > 0 && namespace.length > 0) {
                           let to = '/namespaces/' + namespace + '/services/' + servicename;
                           return (
@@ -229,7 +227,14 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
                         {(rule.route || []).map((label, u) =>
                           Object.keys(label.labels || new Map()).map((key, n) => (
                             <li key={'rule_' + i + '_label_' + u + '_n_' + n}>
-                              {key} : {label.labels[key]}
+                              <ServiceInfoBadge
+                                key={'rule_labels_badge_' + i}
+                                scale={0.8}
+                                style="plastic"
+                                color="green"
+                                leftText={key}
+                                rightText={label.labels ? label.labels[key] : ''}
+                              />
                             </li>
                           ))
                         )}


### PR DESCRIPTION
- Route uses same labels as pods, so it should have same visual identity

![image](https://user-images.githubusercontent.com/1662329/36889095-b5c4cb96-1df8-11e8-9ae3-b95c46ee91e1.png)
