### PR TITLE
SWS-200: Fix Ports overflow on ServiceDetails page

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfo.tsx
@@ -95,7 +95,7 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
                 title={this.state.name}
                 items={
                   <Row>
-                    <Col xs={12} sm={6} md={4} lg={4}>
+                    <Col xs={12} sm={6} md={2} lg={2}>
                       <div className="progress-description">
                         <strong>Labels</strong>
                       </div>
@@ -116,15 +116,17 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
                         <strong> Ip</strong> {this.state.ip ? this.state.ip : ''}
                       </div>
                     </Col>
-                    <Col xs={12} sm={6} md={2} lg={2}>
+                    <Col xs={12} sm={6} md={4} lg={4}>
                       <div className="progress-description">
                         <strong>Ports</strong>
                       </div>
+                      <ul style={{ listStyleType: 'none' }}>
                       {(this.state.ports || []).map((port, i) => (
-                        <span style={{ marginLeft: '10px' }} key={'port_' + i}>
+                        <li key={'port_' + i}>
                           {port.protocol} {port.name} ({port.port})
-                        </span>
+                        </li>
                       ))}
+                      </ul>
                     </Col>
                     <Col xs={12} sm={6} md={6} lg={6}>
                       <div className="progress-description">


### PR DESCRIPTION
- Port is shown as a list instead

![image](https://user-images.githubusercontent.com/1662329/36890133-1592ccd6-1dfd-11e8-8bd5-a06559325ba8.png)
