### PR TITLE
SWS-161 Let prettier infer the format by the path

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,4 @@
 {
   "printWidth": 120,
-  "parser": "typescript",
   "singleQuote": true
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "copy-fonts": "cp -r node_modules/patternfly/dist/fonts src/",
     "copy-img": "cp -r node_modules/patternfly/dist/img src/",
     "build-css": "node-sass-chokidar src/ --output-style compressed $npm_package_sassIncludes_src $npm_package_sassIncludes_patternfly $npm_package_sassIncludes_patternflyReact $npm_package_sassIncludes_bootstrap $npm_package_sassIncludes_fontAwesome -o src/",
-    "prettier": "prettier --single-quote --parser typescript --print-width 120 --write \"src/**/*.{js,jsx,ts,tsx,json}\"",
+    "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json}\"",
     "lint": "tslint --project ./tsconfig.json",
     "start": "npm run copy-fonts && npm run copy-img && npm run build-css && npm run prettier && react-scripts-ts start",
     "build": "npm run copy-fonts && npm run copy-img && npm run build-css && npm run prettier && react-scripts-ts build",


### PR DESCRIPTION
This allows to parse json files
 Removes options on package.json, they were already defined in .prettierrc.json

Before:
![screenshot from 2018-03-05 11-31-29](https://user-images.githubusercontent.com/3845764/36990247-aecd542a-2069-11e8-9795-5698c1c00ddf.png)

After:
![screenshot from 2018-03-05 11-31-37](https://user-images.githubusercontent.com/3845764/36990256-b849dac8-2069-11e8-90d2-af5590f8dc28.png)
