### PR TITLE
DivlessWrapper allows us to remove the unneeded 'div' wrapper

### DIFF
--- a/src/components/DivlessWrapper/DivlessWrapper.tsx
+++ b/src/components/DivlessWrapper/DivlessWrapper.tsx
@@ -1,0 +1,7 @@
+// Allows us to not use a traditional <div> tag to return results (which can cause rendering issues)
+// this gives us a div less wrapper around child components
+// In a medium sized app this will eliminated thousands of unneeded divs.
+
+const DivlessWrapper = (props: any) => props.children;
+
+export default DivlessWrapper;

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -7,6 +7,7 @@ import HelpDropdown from './HelpDropdown';
 import ServiceDetailsPage from '../../pages/ServiceDetails/ServiceDetailsPage';
 import ServiceGraphPage from '../../pages/ServiceGraph/ServiceGraphPage';
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
+import DivlessWrapper from '../DivlessWrapper/DivlessWrapper';
 
 const serviceGraphPath = '/service-graph/istio-system';
 const serviceGraphTitle = 'Graph';
@@ -36,7 +37,7 @@ class Navigation extends React.Component {
 
   render() {
     return (
-      <div>
+      <DivlessWrapper>
         <VerticalNav>
           <VerticalNav.Masthead title="Swift Sunshine">
             <VerticalNav.Brand iconImg={pfLogo} titleImg={pfBrand} />
@@ -58,7 +59,7 @@ class Navigation extends React.Component {
           <Route path="/namespaces/:namespace/services/:service" component={ServiceDetailsPage} />
           <Redirect to={serviceGraphPath} />
         </Switch>
-      </div>
+      </DivlessWrapper>
     );
   }
 }


### PR DESCRIPTION
These High Order Components are very powerful for templates and such, as they can wrap (or decorate) their children. This is a simple one but good for starters and highly useful.
I didn't globally replace all the top level divs; I figured the individual authors can do this. More of these coming...

I also didn't create a jira for this since it is just a refactoring.