### PR TITLE
SWS-260 Add tests and mock for service API

### DIFF
--- a/src/services/__mockData__/getGrafanaInfo.json
+++ b/src/services/__mockData__/getGrafanaInfo.json
@@ -1,0 +1,4 @@
+{
+  "url": "http://172.30.139.113:3000",
+  "variablesSuffix": "svc.cluster.local"
+}

--- a/src/services/__mockData__/getGrafanaInfo.json
+++ b/src/services/__mockData__/getGrafanaInfo.json
@@ -1,4 +1,7 @@
 {
   "url": "http://172.30.139.113:3000",
-  "variablesSuffix": "svc.cluster.local"
+  "variablesSuffix": "svc.cluster.local",
+  "dashboard": "istio-dashboard",
+  "varServiceSource": "var-source",
+  "varServiceDest": "var-http_destination"
 }

--- a/src/services/__mockData__/getGraphElements.json
+++ b/src/services/__mockData__/getGraphElements.json
@@ -1,0 +1,75 @@
+{
+  "elements": {
+    "nodes": [
+      {
+        "data": {
+          "id": "n2",
+          "text": "details (v1)",
+          "service": "details.istio-system.svc.cluster.local",
+          "version": "v1",
+          "link_prom_graph":
+            "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22details.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+        }
+      },
+      {
+        "data": {
+          "id": "n1",
+          "text": "productpage (v1)",
+          "service": "productpage.istio-system.svc.cluster.local",
+          "version": "v1",
+          "link_prom_graph":
+            "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22productpage.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+        }
+      },
+      {
+        "data": {
+          "id": "n3",
+          "text": "reviews (v1)",
+          "service": "reviews.istio-system.svc.cluster.local",
+          "version": "v1",
+          "link_prom_graph":
+            "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bdestination_service%3D%22reviews.istio-system.svc.cluster.local%22%2Cdestination_version%3D%22v1%22%7D"
+        }
+      },
+      {
+        "data": {
+          "id": "n0",
+          "text": "unknown",
+          "service": "unknown",
+          "version": "unknown",
+          "link_prom_graph":
+            "http://prometheus:9090/graph?g0.range_input=1h\u0026g0.tab=0\u0026g0.expr=istio_request_count%7Bsource_service%3D%22unknown%22%2Csource_version%3D%22unknown%22%7D"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "data": {
+          "id": "e0",
+          "source": "n0",
+          "target": "n1",
+          "text": "12.54pm",
+          "color": "green"
+        }
+      },
+      {
+        "data": {
+          "id": "e1",
+          "source": "n1",
+          "target": "n2",
+          "text": "12.54pm",
+          "color": "green"
+        }
+      },
+      {
+        "data": {
+          "id": "e2",
+          "source": "n1",
+          "target": "n3",
+          "text": "12.54pm",
+          "color": "green"
+        }
+      }
+    ]
+  }
+}

--- a/src/services/__mockData__/getNamespaces.json
+++ b/src/services/__mockData__/getNamespaces.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "default"
+  },
+  {
+    "name": "istio-system"
+  },
+  {
+    "name": "kube-public"
+  },
+  {
+    "name": "kube-system"
+  },
+  {
+    "name": "myproject"
+  },
+  {
+    "name": "openshift"
+  },
+  {
+    "name": "openshift-infra"
+  },
+  {
+    "name": "openshift-node"
+  }
+]

--- a/src/services/__mockData__/getServiceDetail.json
+++ b/src/services/__mockData__/getServiceDetail.json
@@ -1,0 +1,113 @@
+{
+  "name": "reviews",
+  "namespace": {
+    "name": "istio-system"
+  },
+  "labels": {
+    "app": "reviews"
+  },
+  "type": "ClusterIP",
+  "ip": "172.30.78.33",
+  "ports": [
+    {
+      "name": "http",
+      "protocol": "TCP",
+      "port": 9080
+    }
+  ],
+  "endpoints": [
+    {
+      "addresses": [
+        {
+          "kind": "Pod",
+          "name": "reviews-v2-4140793682-qrpm9",
+          "ip": "172.17.0.11"
+        },
+        {
+          "kind": "Pod",
+          "name": "reviews-v3-3651831602-zn9g6",
+          "ip": "172.17.0.14"
+        },
+        {
+          "kind": "Pod",
+          "name": "reviews-v1-401049526-tfstp",
+          "ip": "172.17.0.16"
+        }
+      ],
+      "ports": [
+        {
+          "name": "http",
+          "protocol": "TCP",
+          "port": 9080
+        }
+      ]
+    }
+  ],
+  "pods": [
+    {
+      "name": "reviews-v2-4140793682-qrpm9",
+      "labels": {
+        "app": "reviews",
+        "pod-template-hash": "4140793682",
+        "version": "v2"
+      }
+    },
+    {
+      "name": "reviews-v3-3651831602-zn9g6",
+      "labels": {
+        "app": "reviews",
+        "pod-template-hash": "3651831602",
+        "version": "v3"
+      }
+    },
+    {
+      "name": "reviews-v1-401049526-tfstp",
+      "labels": {
+        "app": "reviews",
+        "pod-template-hash": "401049526",
+        "version": "v1"
+      }
+    }
+  ],
+  "route_rules": [
+    {
+      "name": "reviews-default",
+      "destination": {
+        "name": "reviews"
+      },
+      "precedence": 1,
+      "route": [
+        {
+          "labels": {
+            "version": "v1"
+          }
+        }
+      ],
+      "match": null
+    },
+    {
+      "name": "reviews-test-v2",
+      "destination": {
+        "name": "reviews"
+      },
+      "precedence": 2,
+      "route": [
+        {
+          "labels": {
+            "version": "v2"
+          }
+        }
+      ],
+      "match": {
+        "request": {
+          "headers": {
+            "cookie": {
+              "regex": "^(.*?;)?(user=jason)(;.*)?$"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "dependencies": {}
+}

--- a/src/services/__mockData__/getServices.json
+++ b/src/services/__mockData__/getServices.json
@@ -1,0 +1,43 @@
+{
+  "namespace": {
+    "name": "istio-system"
+  },
+  "services": [
+    {
+      "name": "details"
+    },
+    {
+      "name": "grafana"
+    },
+    {
+      "name": "istio-ingress"
+    },
+    {
+      "name": "istio-mixer"
+    },
+    {
+      "name": "istio-pilot"
+    },
+    {
+      "name": "productpage"
+    },
+    {
+      "name": "prometheus"
+    },
+    {
+      "name": "ratings"
+    },
+    {
+      "name": "reviews"
+    },
+    {
+      "name": "servicegraph"
+    },
+    {
+      "name": "sws"
+    },
+    {
+      "name": "zipkin"
+    }
+  ]
+}

--- a/src/services/__mocks__/Api.ts
+++ b/src/services/__mocks__/Api.ts
@@ -1,0 +1,66 @@
+const fs = require('fs');
+
+export const GetNamespaces = () => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(`./src/services/__mockData__/getNamespaces.json`, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        // Parse the data as JSON and put in the key entity (just like the request library does)
+        resolve(JSON.parse(data));
+      }
+    });
+  });
+};
+
+export const GetServices = (namespace: String) => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(`./src/services/__mockData__/getServices.json`, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        // Parse the data as JSON and put in the key entity (just like the request library does)
+        resolve(JSON.parse(data));
+      }
+    });
+  });
+};
+
+export const getGrafanaInfo = () => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(`./src/services/__mockData__/getGrafanaInfo.json`, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        // Parse the data as JSON and put in the key entity (just like the request library does)
+        resolve(JSON.parse(data));
+      }
+    });
+  });
+};
+
+export const GetGraphElements = (namespace: String, params: any) => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(`./src/services/__mockData__/getGraphElements.json`, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        // Parse the data as JSON and put in the key entity (just like the request library does)
+        resolve(JSON.parse(data));
+      }
+    });
+  });
+};
+
+export const GetServiceDetail = (namespace: String, service: String) => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(`./src/services/__mockData__/getServiceDetail.json`, 'utf8', (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        // Parse the data as JSON and put in the key entity (just like the request library does)
+        resolve(JSON.parse(data));
+      }
+    });
+  });
+};

--- a/src/services/__tests__/Api.test.tsx
+++ b/src/services/__tests__/Api.test.tsx
@@ -1,0 +1,62 @@
+jest.mock('../Api');
+
+const API = require('../Api');
+
+describe('#GetNamespaces using Promises', () => {
+  it('should load namespaces', () => {
+    return API.GetNamespaces().then(data => {
+      expect(data).toBeDefined();
+      expect(data).toBeInstanceOf(Array);
+    });
+  });
+});
+
+describe('#GetServices using Promises', () => {
+  it('should load services of namespace', () => {
+    return API.GetServices('istio-system').then(data => {
+      expect(data).toBeDefined();
+      expect(data.namespace.name).toEqual('istio-system');
+      expect(data.services).toBeDefined();
+      expect(data.services).toBeInstanceOf(Array);
+    });
+  });
+});
+
+describe('#getGrafanaInfo using Promises', () => {
+  it('should load the information about grafana', () => {
+    return API.getGrafanaInfo().then(data => {
+      expect(data).toBeDefined();
+      expect(data.url).toBeDefined();
+      expect(data.variablesSuffix).toBeDefined();
+    });
+  });
+});
+
+describe('#GetGraphElements using Promises', () => {
+  it('should load service detail data', () => {
+    return API.GetGraphElements('istio-system', null).then(data => {
+      expect(data).toBeDefined();
+      expect(data.elements).toBeDefined();
+      expect(data.elements.nodes).toBeDefined();
+      expect(data.elements.nodes).toBeInstanceOf(Array);
+      expect(data.elements.edges).toBeDefined();
+      expect(data.elements.edges).toBeInstanceOf(Array);
+    });
+  });
+});
+
+describe('#GetServiceDetail using Promises', () => {
+  it('should load service detail data', () => {
+    return API.GetServiceDetail('istio-system', 'reviews').then(data => {
+      expect(data).toBeDefined();
+      expect(data.name).toEqual('reviews');
+      expect(data.namespace.name).toEqual('istio-system');
+      expect(data.labels).toBeInstanceOf(Object);
+      expect(data.ports).toBeInstanceOf(Array);
+      expect(data.endpoints).toBeInstanceOf(Array);
+      expect(data.pods).toBeInstanceOf(Array);
+      expect(data.route_rules).toBeInstanceOf(Array);
+      expect(data.dependencies).toBeInstanceOf(Object);
+    });
+  });
+});


### PR DESCRIPTION
Jira: [SWS-260](https://issues.jboss.org/browse/SWS-260)

Add tests and mocks for Service API. 

With this we can mock the API calls in the tests.
Example test of ServiceDescription, thanks for @vnugent, great masterclass 

```js
import * as React from 'react';
import { shallow } from 'enzyme';
import { ServiceInfoDescription, ServiceInfoCard } from '../index';

jest.mock('../../../../services/Api');

const API = require('../../../../services/Api');

describe('#ServiceInfoDescription render correctly with data', () => {
  it('should load service detail data', () => {
    return API.GetServiceDetail('istio-system', 'reviews').then(data => {
      const wrapper = shallow(
        <ServiceInfoDescription
          name={data.name}
          labels={data.labels}
          type={data.type}
          ip={data.ip}
          endpoints={data.endpoints}
        />
      );
      expect(wrapper).toBeDefined();
      expect(wrapper.find(ServiceInfoCard).props().iconType).toEqual('pf');
      expect(wrapper.find(ServiceInfoCard).props().iconName).toEqual('service');
      expect(wrapper.find(ServiceInfoCard).props().title).toEqual(data.name);
    });
  });
});

```