### PR TITLE
[SWS-256] Restore main app test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   },
   "dependencies": {
     "axios": "~0.17.1",
-    "axios-mock-adapter": "~1.12.0",
     "lodash": "~4.17.5",
     "patternfly": "~3.38.1",
     "patternfly-react": "~1.8.2",
@@ -44,6 +43,7 @@
     "@types/react": "~16.0.36",
     "@types/react-dom": "~16.0.3",
     "@types/react-router-dom": "^4.2.4",
+    "axios-mock-adapter": "^1.14.1",
     "babel-core": "^6.26.0",
     "coveralls": "^3.0.0",
     "enzyme": "^3.3.0",

--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -2,8 +2,20 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import App from '../App';
 
-// Skipping full App rendering for now until we properly mock Cytoscape
-test.skip('renders App without crashing', () => {
+const axios = require('axios');
+const MockAdapter = require('axios-mock-adapter');
+
+// Mock graph component due to direct DOM/div access
+jest.mock('../../components/CytoscapeLayout/CytoscapeLayout');
+
+const mock = new MockAdapter(axios);
+mock.onAny().reply(200);
+
+process.env.REACT_APP_NAME = 'swsui-test';
+process.env.REACT_APP_VERSION = '1.0.1';
+process.env.REACT_APP_GIT_HASH = '89323';
+
+it('renders full App without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(<App />, div);
 });

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -38,7 +38,7 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
   }
 
   populateNamespacesSelect(response: any) {
-    this.setState({ availableNamespaces: response['data'] });
+    this.setState({ availableNamespaces: response['data'] ? response['data'] : [] });
   }
 
   namespaceSelected(selectedNamespace: string) {


### PR DESCRIPTION
- Re-enable full App render smoke test
- Mock Axios module to return http 200 for all calls
- Move `axios-mock-adapter` module to `devDependencies`. Not sure why it was added in regular deps.
- Add a null/undefined guard for `ServiceGraphPage.availableNamespaces`
- Temporarily mock Cytoscape graph component due to DOM/div hack in browser resize logic