### PR TITLE
Restore cytoscape smoke test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1226,9 +1226,10 @@
       }
     },
     "axios-mock-adapter": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.12.0.tgz",
-      "integrity": "sha1-DD9w70adVWXxjTn96wqyIL15FAo=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.14.1.tgz",
+      "integrity": "sha1-yODuETSVUmdTjVZteuBoviBGcVg=",
+      "dev": true,
       "requires": {
         "deep-equal": "1.0.1"
       }
@@ -7196,6 +7197,12 @@
           }
         }
       }
+    },
+    "jest-canvas-mock": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-1.0.2.tgz",
+      "integrity": "sha512-G1CAStK1S5K7VQjul38Diil1YBhu9OPyX3ngvi08k/fg//MiRir1uJA9jZRxmLRgR+J+Oaa2G9cg58D3r/KRAw==",
+      "dev": true
     },
     "jest-changed-files": {
       "version": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "husky": "^0.14.3",
+    "jest-canvas-mock": "^1.0.2",
     "node-sass-chokidar": "0.0.3",
     "npm-snapshot": "^1.0.3",
     "prettier": "^1.10.2",


### PR DESCRIPTION
Related to SWS-256

Cytoscape smoke test was failing because of two reasons:

1) Cytoscape uses `canvas`, but jsdom doesn't implement it.
2) Cytoscape relies on the values `paddingXXX` provided by `window.getComputedStyle`,  but `jsdom` implementation is not complete, not all values are returned with sane defaults.

Fixed 1) by adding `jest-canvas-mock`.
Fixed 2) by mocking getComputedStyle and adding default for `paddingXXX`.

@vnugent please take a look