### PR TITLE
SWS-94: Add multiple layouts for graphs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1226,9 +1226,10 @@
       }
     },
     "axios-mock-adapter": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.12.0.tgz",
-      "integrity": "sha1-DD9w70adVWXxjTn96wqyIL15FAo=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.14.1.tgz",
+      "integrity": "sha1-yODuETSVUmdTjVZteuBoviBGcVg=",
+      "dev": true,
       "requires": {
         "deep-equal": "1.0.1"
       }

--- a/src/components/CytoscapeLayout/CytoscapeLayout.tsx
+++ b/src/components/CytoscapeLayout/CytoscapeLayout.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { ReactCytoscape } from 'react-cytoscape';
-import { CytoscapeConfig } from './CytoscapeConfig';
 import * as API from '../../services/Api';
 import PropTypes from 'prop-types';
+import { GraphStyles } from './graphs/GraphStyles';
 
 type CytoscapeLayoutState = {
   elements?: any;
 };
 
 type CytoscapeLayoutProps = {
-  // none yet
-  namespace: any;
+  namespace: string;
+  layout: any;
 };
 
 export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProps, CytoscapeLayoutState> {
@@ -56,10 +56,10 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
   cyRef(cy: any) {
     this.cy = cy;
     cy.on('tap', 'node', (evt: any) => {
-      let target = evt.target;
-      let targetNode = cy.$id(target.id());
-      let svc = targetNode.data('service');
-      let service = svc.split('.')[0];
+      const target = evt.target;
+      const targetNode = cy.$id(target.id());
+      const svc = targetNode.data('service');
+      const service = svc.split('.')[0];
       if (service !== 'internet') {
         this.context.router.history.push('/namespaces/' + this.props.namespace + '/services/' + service);
       }
@@ -75,14 +75,9 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
             this.cyRef(cy);
           }}
           elements={this.state.elements}
-          style={CytoscapeConfig.getStyles()}
-          cytoscapeOptions={{ wheelSensitivity: 0.1, autounselectify: false }}
-          layout={{
-            name: 'breadthfirst',
-            directed: 'true',
-            maximalAdjustments: 2,
-            spacingFactor: 1
-          }}
+          style={GraphStyles.styles()}
+          cytoscapeOptions={GraphStyles.options()}
+          layout={this.props.layout}
         />
       </div>
     );

--- a/src/components/CytoscapeLayout/graphs/BreadthFirstGraph.ts
+++ b/src/components/CytoscapeLayout/graphs/BreadthFirstGraph.ts
@@ -1,0 +1,12 @@
+import { GraphType } from './GraphType';
+
+export class BreadthFirstGraph implements GraphType {
+  static getLayout() {
+    return {
+      name: 'breadthfirst',
+      directed: 'true',
+      maximalAdjustments: 2,
+      spacingFactor: 1
+    };
+  }
+}

--- a/src/components/CytoscapeLayout/graphs/ColaGraph.ts
+++ b/src/components/CytoscapeLayout/graphs/ColaGraph.ts
@@ -1,0 +1,9 @@
+import { GraphType } from './GraphType';
+
+export class ColaGraph implements GraphType {
+  static getLayout() {
+    return {
+      name: 'cola'
+    };
+  }
+}

--- a/src/components/CytoscapeLayout/graphs/DagreGraph.ts
+++ b/src/components/CytoscapeLayout/graphs/DagreGraph.ts
@@ -1,0 +1,9 @@
+import { GraphType } from './GraphType';
+
+export class DagreGraph implements GraphType {
+  static getLayout() {
+    return {
+      name: 'dagre'
+    };
+  }
+}

--- a/src/components/CytoscapeLayout/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphStyles.ts
@@ -1,5 +1,9 @@
-export class CytoscapeConfig {
-  static getStyles() {
+export class GraphStyles {
+  static options() {
+    return { wheelSensitivity: 0.1, autounselectify: false };
+  }
+
+  static styles() {
     return [
       {
         selector: 'node',
@@ -9,8 +13,21 @@ export class CytoscapeConfig {
           },
           color: 'black',
           'background-color': '#bbb',
+          'border-width': '1px',
+          'border-color': '#000',
+          'font-size': '10px',
           'text-valign': 'center',
           'text-halign': 'right'
+        }
+      },
+      {
+        selector: 'node:selected',
+        style: {
+          'border-width': '3px',
+          'border-color': '#116CD6',
+          'border-opacity': '0.7',
+          'background-color': '#77828C',
+          'text-outline-color': '#77828C'
         }
       },
       {
@@ -32,7 +49,9 @@ export class CytoscapeConfig {
         selector: 'edge',
         css: {
           width: 3,
-          color: '#666',
+          color: '#434343',
+          opacity: '0.8',
+          'font-size': '8px',
           content: 'data(text)',
           'target-arrow-shape': 'vee',
           'line-color': 'data(color)',
@@ -47,6 +66,14 @@ export class CytoscapeConfig {
           'line-color': '#84B5EA',
           'target-arrow-color': '#84B5EA',
           'source-arrow-color': '#84B5EA'
+        }
+      },
+      {
+        selector: 'edge.highlighted',
+        style: {
+          'line-color': '#116CD6',
+          opacity: '0.95',
+          width: '25px'
         }
       }
     ];

--- a/src/components/CytoscapeLayout/graphs/GraphType.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphType.ts
@@ -1,0 +1,4 @@
+export interface GraphType {
+  // @todo this is just a Marker Interface until we can figure out a Static Method I/F
+  // static getLayout(): any;
+}

--- a/src/components/Pf/PfContainerNavVertical.tsx
+++ b/src/components/Pf/PfContainerNavVertical.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PfContainerNavVertical = props => {
+  return <div className="container-fluid container-pf-nav-pf-vertical">{props.children}</div>;
+};
+
+export default PfContainerNavVertical;

--- a/src/components/Pf/PfHeader.tsx
+++ b/src/components/Pf/PfHeader.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+type PfHeaderProps = {
+  // none yet
+};
+
+const PfHeader: React.SFC<PfHeaderProps> = props => {
+  return <div className="page-header">{props.children}</div>;
+};
+
+export default PfHeader;

--- a/src/pages/ServiceGraph/CytoscapeToolbar.tsx
+++ b/src/pages/ServiceGraph/CytoscapeToolbar.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { ButtonGroup, Button } from 'patternfly-react';
+import PropTypes from 'prop-types';
+
+type CytoscapeToolbarProps = {
+  graphType: PropTypes.func;
+};
+
+type CytoscapeToolbarState = {
+  // none
+};
+
+class CytoscapeToolbar extends React.Component<CytoscapeToolbarProps, CytoscapeToolbarState> {
+  constructor(props: CytoscapeToolbarProps) {
+    super(props);
+  }
+
+  dagre = () => {
+    this.props.graphType('Dagre');
+  };
+
+  cola = () => {
+    this.props.graphType('Cola');
+  };
+
+  breadthFirst = () => {
+    this.props.graphType('Breadthfirst');
+  };
+
+  render() {
+    return (
+      <ButtonGroup>
+        <Button onClick={this.cola}>Cola</Button>
+        <Button onClick={this.dagre}>Dagre</Button>
+        <Button onClick={this.breadthFirst}>Breadthfirst</Button>
+      </ButtonGroup>
+    );
+  }
+}
+
+export default CytoscapeToolbar;

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -4,12 +4,21 @@ import { RouteComponentProps } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import NamespaceId from '../../types/NamespaceId';
 import CytoscapeLayout from '../../components/CytoscapeLayout/CytoscapeLayout';
-import { DropdownButton, MenuItem } from 'patternfly-react';
+import { DropdownButton, MenuItem, Alert } from 'patternfly-react';
+import CytoscapeToolbar from './CytoscapeToolbar';
+import PfContainerNavVertical from '../../components/Pf/PfContainerNavVertical';
+import PfHeader from '../../components/Pf/PfHeader';
+import { DagreGraph } from '../../components/CytoscapeLayout/graphs/DagreGraph';
+import { ColaGraph } from '../../components/CytoscapeLayout/graphs/ColaGraph';
+import { BreadthFirstGraph } from '../../components/CytoscapeLayout/graphs/BreadthFirstGraph';
 import SummaryPanel from './SummaryPanel';
 
 type ServiceGraphPageProps = {
   availableNamespaces: { name: string }[];
   graphNamespace: string;
+  alertVisible: boolean;
+  alertDetails: string;
+  layout: any;
 };
 
 export default class ServiceGraphPage extends React.Component<RouteComponentProps<NamespaceId>, ServiceGraphPageProps> {
@@ -19,18 +28,24 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
 
   constructor(routeProps: RouteComponentProps<NamespaceId>) {
     super(routeProps);
-    this.namespaceSelected = this.namespaceSelected.bind(this);
-
     this.state = {
       availableNamespaces: [],
-      graphNamespace: routeProps.match.params.namespace
+      graphNamespace: routeProps.match.params.namespace,
+      alertVisible: false,
+      alertDetails: '',
+      layout: 'Cola'
     };
 
     this.populateNamespacesSelect = this.populateNamespacesSelect.bind(this);
   }
 
   componentDidMount() {
-    API.GetNamespaces().then(this.populateNamespacesSelect);
+    API.GetNamespaces()
+      .then(this.populateNamespacesSelect)
+      .catch(namespacesError => {
+        console.error(JSON.stringify(namespacesError));
+        this.handleError('Error fetching namespace list.');
+      });
   }
 
   componentWillReceiveProps(nextProps: RouteComponentProps<NamespaceId>) {
@@ -38,23 +53,53 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
   }
 
   populateNamespacesSelect(response: any) {
-    this.setState({ availableNamespaces: response['data'] ? response['data'] : [] });
+    const namespaces = response['data'] ? response['data'] : [];
+    this.setState({ availableNamespaces: namespaces });
   }
 
-  namespaceSelected(selectedNamespace: string) {
+  namespaceSelected = (selectedNamespace: string) => {
     this.context.router.history.push(`/service-graph/${selectedNamespace}`);
-  }
+  };
+
+  clickGraphType = (name: string) => {
+    if (name === 'Dagre') {
+      this.setState({ layout: DagreGraph.getLayout() });
+    } else if (name === 'Cola') {
+      this.setState({ layout: ColaGraph.getLayout() });
+    } else if (name === 'Breadthfirst') {
+      this.setState({ layout: BreadthFirstGraph.getLayout() });
+    } else {
+      this.setState({ layout: DagreGraph.getLayout() });
+    }
+  };
+
+  handleError = (error: string) => {
+    this.setState({ alertVisible: true, alertDetails: error });
+  };
+
+  dismissAlert = () => {
+    this.setState({ alertVisible: false });
+  };
 
   render() {
+    let alertsDiv = <div />;
+    if (this.state.alertVisible) {
+      alertsDiv = (
+        <div>
+          <Alert onDismiss={this.dismissAlert}>{this.state.alertDetails.toString()}</Alert>
+        </div>
+      );
+    }
     return (
-      <div className="container-fluid container-pf-nav-pf-vertical">
-        <div className="page-header">
+      <PfContainerNavVertical>
+        <PfHeader>
           <h2>
-            Services Graph for namespace:&nbsp;
+            Services Graph for namespace:
             <DropdownButton
               id="namespace-selector"
               title={this.state.graphNamespace}
               onSelect={this.namespaceSelected}
+              style={{ marginLeft: 20 }}
               bsSize="large"
             >
               {this.state.availableNamespaces.map(ns => (
@@ -64,12 +109,14 @@ export default class ServiceGraphPage extends React.Component<RouteComponentProp
               ))}
             </DropdownButton>
           </h2>
-        </div>
+          {alertsDiv}
+        </PfHeader>
         <div style={{ position: 'relative' }}>
           <SummaryPanel />
-          <CytoscapeLayout namespace={this.state.graphNamespace} />
+          <CytoscapeToolbar graphType={this.clickGraphType} />
+          <CytoscapeLayout namespace={this.state.graphNamespace} layout={this.state.layout} />
         </div>
-      </div>
+      </PfContainerNavVertical>
     );
   }
 }


### PR DESCRIPTION
Instead of just the one layout, add multiple layout options(3) for the graphs selectable on a toolbar.
![graph-types](https://user-images.githubusercontent.com/1312165/37191739-5e92f06e-2316-11e8-84cb-ce93902b6525.gif)

There are still two other layouts that need to be added: cosa and klay (their configurations and libraries are more complicated). But nothing stopping this from being merged.

[SWS-94](https://issues.jboss.org/browse/SWS-194)